### PR TITLE
get user from tty1 when tty7 unavailable

### DIFF
--- a/notify-awesome
+++ b/notify-awesome
@@ -1,6 +1,12 @@
 #! /bin/sh
 
-USER=`who |grep tty7|awk '{print $1}'`
+USER=`who | grep tty7 | awk '{print $1}'`
+
+# if no tty7, try tty1
+
+if [ -z "$USER" ]; then
+	USER=`who | grep tty1 | awk '{print $1}'`
+fi
 
 function notify {
 	su $USER -c "export DISPLAY=':0.0'; \


### PR DESCRIPTION
On my system (a minimal Debian using awesome alone) there is no result for `who | grep tty7` and the blank string results in a failure to notify the awesome client. This slight modification gets the user from tty1 if the tty7 user is blank.