### PR TITLE
fix /etc/udev/rules.d/

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Since configuration file is also lua script you can do many things when screens 
 Install
 =======
 
-* 98-screen-detect.rules - copy to /etc/udev/rules and execute with root privileges `udevadm control --reload-rules`
+* 98-screen-detect.rules - copy to /etc/udev/rules.d/ and execute with root privileges `udevadm control --reload-rules`
 * notify-awesome - copy to /lib/udev and add execution bit
 * screenful.lua - copy to ~/.config/awesome
 * screens_db.lua - copy to ~/.config/awesome


### PR DESCRIPTION
On my system (and I believe all) the actual directory is /etc/udev/rules.d/. 

This patch fixes that in the readme.