### PR TITLE
Ability improments and some bug fix

### DIFF
--- a/notify-awesome
+++ b/notify-awesome
@@ -5,19 +5,26 @@ USER=`who | grep tty7 | awk '{print $1}'`
 # if no tty7, try tty1
 
 if [ -z "$USER" ]; then
-	USER=`who | grep tty1 | awk '{print $1}'`
+    USER=`who | grep tty1 | awk '{print $1}'`
 fi
 
 # if no tty1, just pick the first logged in user
 
 if [ -z "$USER" ]; then
-	USER=`who --users | head -1 | awk '{print $1}'`
+    USER=`who --users | head -1 | awk '{print $1}'`
 fi
 
+
 notify() {
-	su $USER -c "export DISPLAY=':0.0'; \
-                 export XAUTHORITY='/home/$USER/.Xauthority'; \
-		 echo 'updateScreens(\"$1\")' | awesome-client"
-}
+    _UID=`id -u $USER`
+    su $USER -c "/bin/bash \
+                    -c ' \
+                        export DISPLAY=:0; \
+                        export XAUTHORITY='/home/$USER/.Xauthority'; \
+                        export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$_UID/bus; \
+                        awesome-client updateScreens\(\\\"$1\\\"\) \
+                    ' \
+                "
+    }
 
 notify $1 &

--- a/screenful.lua
+++ b/screenful.lua
@@ -7,7 +7,6 @@
 local naughty = require('naughty')
 local awful = require("awful")
 local io = require("io")
-local utils = require("utils")
 require('screens_db')
 
 local waitForEdid = 30

--- a/screenful.lua
+++ b/screenful.lua
@@ -8,7 +8,6 @@ local naughty = require('naughty')
 local awful = require("awful")
 local screen = require("awful.screen")
 local io = require("io")
-local utils = require("utils")
 local awesome = awesome
 require('screens_db')
 

--- a/screens_db.lua
+++ b/screens_db.lua
@@ -1,17 +1,32 @@
+local naughty = require("naughty")
+
+local defaultOutput = 'eDP1'
+
+outputMapping = {
+    ['DP-1'] = 'DP1',
+    ['DP-2'] = 'DP2',
+    ['DP-3'] = 'DP3',
+    ['VGA-1'] = 'VGA1',
+    ['LVDS-1'] = 'LVDS1',
+    ['HDMI-A-1'] = 'HDMI1',
+    ['HDMI-A-2'] = 'HDMI2',
+    ['eDP-1'] = 'eDP1',
+    ['eDP-2'] = 'eDP2',
+}
+
 screens = {
 	['default'] = {
 		['connected'] = function (xrandrOutput)
-			return '--output ' .. xrandrOutput .. ' --auto --same-as LVDS1'
+            if xrandrOutput ~= defaultOutput then
+                return '--output ' .. xrandrOutput .. ' --auto --same-as ' .. defaultOutput
+            end
+            return nil
 		end,
 		['disconnected'] = function (xrandrOutput)
-			return '--output ' .. xrandrOutput .. ' --off --output LVDS1 --auto'
+            if xrandrOutput ~= defaultOutput then
+                return '--output ' .. xrandrOutput .. ' --off --output ' .. defaultOutput .. ' --auto'
+            end
+            return nil
 		end
 	},
-	['55250827610'] = {
-		['connected'] = function (xrandrOutput)
-			return '--output ' .. xrandrOutput .. ' --auto --above LVDS1'
-		end,
-		['disconnected'] = nil
-	}
 }
-


### PR DESCRIPTION
1. notify-awesome: fix an issue when user's shell is not bash (usually
syntax errors).

2. screenful.lua: move outputMapping to screens_db.lua file, because
this variable is more like a configuration stuff.

3. screenful.lua: change template of appendConfiguration() function, in
order  to give it a clear meaning of screens_db.lua's comments.

4. screenful.lua: appendConfiguration(screenId) -->
appendConfiguration(screenId, xrandrOut), because of **3** above

5. screens_db.lua: add an variable defaultOutput, when new connected
output's name equals to defaultOutput, do nothing.