### PR TITLE
fixed cgroup udev deadlock

### DIFF
--- a/notify-awesome
+++ b/notify-awesome
@@ -1,28 +1,18 @@
 #!/bin/sh
 
-USER=`who | grep tty7 | awk '{print $1}'`
-
-# if no tty7, try tty1
-
-if [ -z "$USER" ]; then
-    USER=`who | grep tty1 | awk '{print $1}'`
-fi
-
-# if no tty1, just pick the first logged in user
-
-if [ -z "$USER" ]; then
-    USER=`who --users | head -1 | awk '{print $1}'`
-fi
-
+_PID=$(pgrep -x awesome)
+_UID=$(ps -o uid= -p $_PID)
+USER=$(id -nu $_UID)
+DBUS_ADDRESS_VAR=$(cat /proc/$_PID/environ | grep -z "^DBUS_SESSION_BUS_ADDRESS=")
 
 notify() {
-    _UID=`id -u $USER`
-    su $USER -c "/bin/bash \
+  	su - $USER -c "/bin/bash \
                     -c ' \
                         export DISPLAY=:0; \
                         export XAUTHORITY='/home/$USER/.Xauthority'; \
-                        export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/$_UID/bus; \
-                        awesome-client updateScreens\(\\\"$1\\\"\) \
+                        export $DBUS_ADDRESS_VAR; \
+                        dbus-send --dest=org.awesomewm.awful --type=method_call \
+                          / org.awesomewm.awful.Remote.Eval string:"updateScreens\\\(\\\"$1\\\"\\\)" \
                     ' \
                 "
     }


### PR DESCRIPTION
I experienced a little problem with your code on modern cgroup-based udev versions (Fedora 29+). Because the edid is not written till the udev events finish (don't know exactly why) your edid-retry code runs into some kind of deadlock/race-condition situation.

First I tried to fix it by adding a call to `udevadm settle` but this leads to a complete deadlock scenario. I think this does not happen on "traditional"/non-cgroup udev implementations because you already fixed this by spawning a background-task inside the udev-rule. This helps on old versions, but on a cgroup setup all processes (even background ones) are expected to finish before the rule completes. My fix uses dbus-send (without waiting for a result) instead of awesome-client to start the updateScreens call. This resolves the race-condition and waits till the edid is properly set (by using `udevadm settle`) so it should even be more error-resistant on slow systems.

Thx this cool project! Please think about publishing it under an open-source license to make additions like this a bit less problematic. I simply assumed that it is ok to provide modifications/patches based on your past approvements of PRs. Legally it is not clear if you are allowing modification or even usage of your code. So please please please add some kind of license information, on GitHub its just one click away